### PR TITLE
Extend error-checking for method lookup.

### DIFF
--- a/ipyhop/planner.py
+++ b/ipyhop/planner.py
@@ -827,6 +827,10 @@ class IPyHOP(object):
                 except KeyError:
                     raise KeyError("Input tree contains method, " + method_name +
                                    ", but no method of this name was found in the domain definition")
+                except IndexError:
+                    raise KeyError("Input tree contains method, " + method_name +
+                                   ", but no method of this name was found in the domain definition")
+
                 info_dict[ task_id ].update(
                     {
                         "selected_method": selected_method_name,


### PR DESCRIPTION
Previously the error-checking caught `AttributeError` in case there was a failure to find a method name as key.  However, an error (the only error?) that can happen is that the code finds all the matching methods, finds them in a list comprehension (expected to be exactly one element long), and then takes the first element of the resulting list.

If no match is found, the list is empty, and we get a `KeyError` trying to take the first element of an empty list. I added a check for that exception, as well.